### PR TITLE
Update main.cpp grader and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@
 *.exe
 *.out
 *.app
+test
+main
+
+# VSCode
+.vscode
 
 # Zone Identifiers - for WSL
 *Zone*

--- a/plagiarism_checker/phase1/main.cpp
+++ b/plagiarism_checker/phase1/main.cpp
@@ -1,11 +1,13 @@
-#include "match_submissions.hpp"
+#include <iomanip>
+
 #include "../tokenizer.hpp"
+#include "match_submissions.hpp"
 
 // You should NOT modify ANYTHING in this file.
-extern std::array<int, 5> match_submissions(std::vector<int> &submission1, 
-        std::vector<int> &submission2);
+extern std::array<int, 5> match_submissions(std::vector<int> &submission1,
+                                            std::vector<int> &submission2);
 
-double execute_and_verify_testcase(std::string test_dir) {
+void execute_and_verify_testcase(std::string test_dir) {
     tokenizer_t file_one(test_dir + "/one.cpp");
     tokenizer_t file_two(test_dir + "/two.cpp");
     std::vector<int> submission1 = file_one.get_tokens();
@@ -14,31 +16,26 @@ double execute_and_verify_testcase(std::string test_dir) {
 
     std::ifstream in(test_dir + "/expected.txt");
     std::array<int, 5> expected;
-    in >> expected[0] >> expected[1] >> expected[2] >> 
-            expected[3] >> expected[4];
+    in >> expected[0] >> expected[1] >> expected[2] >>
+        expected[3] >> expected[4];
     in.close();
 
-    std::array<double, 5> results;
-    results[0] = (output[0] == expected[0]) ? 1.0 : 0.0;
-    results[1] = (1.0 * std::min(output[1], expected[1])) / 
-            std::max(output[1], expected[1]);
-    results[2] = (1.0 * std::min(output[2], expected[2])) /
-            std::max(output[2], expected[2]);
-    results[3] = std::pow(1.1, -std::abs(output[3] - expected[3]));
-    results[4] = std::pow(1.1, -std::abs(output[4] - expected[4]));
-    return (2.0 * results[0] + results[1] + results[2] + 
-            0.5 * (results[3] + results[4]));
+    for (int i = 0; i < 5; i++) {
+        std::cout << "Result " << i << ":\t";
+        std::cout << "Your output: " << std::setw(10) << std::left << output[i];
+        std::cout << "\tSample output: " << expected[i] << std::endl;
+    }
+    std::cout << std::endl;
 }
 
 int main(void) {
-    double total_score = 0.0;
-    double score1 = execute_and_verify_testcase("testcases/one");
-    double score2 = execute_and_verify_testcase("testcases/two");
-    double score3 = execute_and_verify_testcase("testcases/three");
-    std::cout << "Testcase 1: " << score1 << " / 5.0" << std::endl;
-    std::cout << "Testcase 2: " << score2 << " / 5.0" << std::endl;
-    std::cout << "Testcase 3: " << score3 << " / 5.0" << std::endl;
-    total_score += score1 + score2 + score3;
-    std::cout << "Total score: " << total_score << " / 15.0" << std::endl;
+    std::cout << "Testcase 1: " << std::endl;
+    execute_and_verify_testcase("testcases/one");
+
+    std::cout << "Testcase 2: " << std::endl;
+    execute_and_verify_testcase("testcases/two");
+
+    std::cout << "Testcase 3: " << std::endl;
+    execute_and_verify_testcase("testcases/three");
     return 0;
 }

--- a/plagiarism_checker/phase1/match_submissions.hpp
+++ b/plagiarism_checker/phase1/match_submissions.hpp
@@ -1,8 +1,8 @@
 #include <array>
+#include <cmath>
 #include <iostream>
 #include <span>
 #include <vector>
-#include <cmath>
 // -----------------------------------------------------------------------------
 
 // You are free to add any STL includes above this comment, below the --line--.
@@ -11,10 +11,10 @@
 
 // OPTIONAL: Add your helper functions and data structures here
 
-std::array<int, 5> match_submissions(std::vector<int> &submission1, 
-        std::vector<int> &submission2) {
+std::array<int, 5> match_submissions(std::vector<int> &submission1,
+                                     std::vector<int> &submission2) {
     // TODO: Write your code here
     std::array<int, 5> result = {0, 0, 0, 0, 0};
-    return result; // dummy return
+    return result;  // dummy return
     // End TODO
 }

--- a/plagiarism_checker/phase1/tokenizer.cpp
+++ b/plagiarism_checker/phase1/tokenizer.cpp
@@ -7,7 +7,7 @@ tokenizer_t::tokenizer_t(std::string __file_name) {
     const char* args[] = {"-std=c++20"};
     this->unit = clang_parseTranslationUnit(
         index,
-        this->file_name.c_str(), 
+        this->file_name.c_str(),
         args, 1,
         nullptr, 0,
         CXTranslationUnit_None);
@@ -24,16 +24,14 @@ tokenizer_t::~tokenizer_t(void) {
 
 std::vector<int> tokenizer_t::get_tokens(void) {
     struct tokenizer_data_t data = {std::vector<int>(), this};
-    clang_visitChildren(clang_getTranslationUnitCursor(this->unit), 
-            [](CXCursor c, CXCursor parent, CXClientData client_data) {
+    clang_visitChildren(clang_getTranslationUnitCursor(this->unit), [](CXCursor c, CXCursor parent, CXClientData client_data) {
                 tokenizer_data_t* data = 
                     reinterpret_cast<tokenizer_data_t*>(client_data);
                 if (data->tokenizer->is_from_main_file(c)) {
                     int token = static_cast<int>(clang_getCursorKind(c));
                     data->tokens.push_back(token);
                 }
-                return CXChildVisit_Recurse;
-            }, reinterpret_cast<CXClientData>(&data));
+                return CXChildVisit_Recurse; }, reinterpret_cast<CXClientData>(&data));
     return data.tokens;
 }
 
@@ -41,7 +39,7 @@ bool tokenizer_t::is_from_main_file(CXCursor __cursor) {
     CXFile cursor_file;
     unsigned line, column, offset;
     clang_getSpellingLocation(clang_getCursorLocation(__cursor),
-            &cursor_file, &line, &column, &offset);
+                              &cursor_file, &line, &column, &offset);
     CXFile main_file = clang_getFile(this->unit, this->file_name.c_str());
     return clang_File_isEqual(cursor_file, main_file);
 }
@@ -49,4 +47,4 @@ bool tokenizer_t::is_from_main_file(CXCursor __cursor) {
 std::string get_cursor_kind_spelling(int kind) {
     return clang_getCString(clang_getCursorKindSpelling(
         static_cast<CXCursorKind>(kind)));
-} 
+}

--- a/plagiarism_checker/tokenizer.hpp
+++ b/plagiarism_checker/tokenizer.hpp
@@ -10,12 +10,12 @@
 // You should NOT modify ANYTHING in this file.
 
 class tokenizer_t {
-public:
+   public:
     tokenizer_t(std::string __file_name);
     ~tokenizer_t(void);
     std::vector<int> get_tokens(void);
 
-protected:
+   protected:
     std::string file_name;
     CXTranslationUnit unit;
     CXIndex index;


### PR DESCRIPTION
- Updated the `main.cpp` file, which grades the submission to **not display any score, instead print the expected data**.
- Updated `.gitignore` to exclude the **executables** and the **.vscode** folder.
- Formatted the files using the formatted mentioned below:
```
⁠ "C_Cpp.clang_format_fallbackStyle": "{BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 0, AllowShortFunctionsOnASingleLine: All, BreakBeforeBraces: Attach}"
```

The above code formatter can be put in the `settings.json` of vscode.